### PR TITLE
fix: adk output schema issues

### DIFF
--- a/adk/untangle_agent/schemas.py
+++ b/adk/untangle_agent/schemas.py
@@ -1,64 +1,79 @@
 from typing import List, Dict, Any
 from pydantic import BaseModel, Field, ConfigDict
+import json
 
-class GlossaryItem(BaseModel):
-    """Individual glossary item with term and definition"""
-    model_config = ConfigDict(extra='forbid')
+def remove_additional_properties(schema: dict) -> dict:
+    """Remove additionalProperties from schema and all nested schemas"""
+    if isinstance(schema, dict):
+        # Remove additionalProperties from current level
+        schema = {k: v for k, v in schema.items() if k != 'additionalProperties'}
+        
+        # Recursively process nested schemas
+        for key, value in schema.items():
+            if isinstance(value, dict):
+                schema[key] = remove_additional_properties(value)
+            elif isinstance(value, list):
+                schema[key] = [remove_additional_properties(item) if isinstance(item, dict) else item for item in value]
+    return schema
+
+class BaseSchema(BaseModel):
+    """Base schema class that removes additionalProperties from JSON schema"""
+    model_config = ConfigDict(extra='allow')
     
+    @classmethod
+    def model_json_schema(cls, **kwargs):
+        """Override to remove additionalProperties from generated schema"""
+        schema = super().model_json_schema(**kwargs)
+        return remove_additional_properties(schema)
+
+class GlossaryItem(BaseSchema):
+    """Individual glossary item with term and definition"""
     term: str = Field(description="The legal or technical term")
     definition: str = Field(description="Clear definition of the term")
 
-class SummaryPoint(BaseModel):
+class SummaryPoint(BaseSchema):
     """Individual summary point with layman and technical explanations"""
-    model_config = ConfigDict(extra='forbid')
-    
     layman_explanation: str = Field(description="Simple, easy-to-understand explanation for general users")
     technical_explanation: str = Field(description="Detailed technical explanation for legal professionals")
     glossary: List[GlossaryItem] = Field(description="List of terms and definitions relevant to this point")
 
-class RiskPhrase(BaseModel):
+class RiskPhrase(BaseSchema):
     """Individual risk phrase with explanations"""
-    model_config = ConfigDict(extra='forbid')
-    
     layman_explanation: str = Field(description="Simple explanation of why this phrase is risky for users")
     technical_explanation: str = Field(description="Technical analysis of the legal implications")
     glossary: List[GlossaryItem] = Field(description="List of terms and definitions relevant to this risk")
 
-class Conclusion(BaseModel):
+class Conclusion(BaseSchema):
     """Overall conclusion with explanations"""
-    model_config = ConfigDict(extra='forbid')
-    
     layman_explanation: str = Field(description="Simple summary of the document's key implications for users")
     technical_explanation: str = Field(description="Technical summary of legal implications and recommendations")
     glossary: List[GlossaryItem] = Field(description="List of terms and definitions relevant to the conclusion")
 
-class DemistifierOutput(BaseModel):
+class DemistifierOutput(BaseSchema):
     """Complete output schema for the demistifier agent pipeline"""
-    model_config = ConfigDict(extra='forbid')
-    
     summary: List[SummaryPoint] = Field(description="Point-wise summary of the legal document")
     risk_phrases: List[RiskPhrase] = Field(description="Array of risky phrases found in the document")
     conclusion: Conclusion = Field(description="Overall conclusion and recommendations")
 
 # Individual agent output schemas
-class RiskEvaluationResult(BaseModel):
+class RiskEvaluationResult(BaseSchema):
     """Output schema for risk evaluator agent"""
-    model_config = ConfigDict(extra='forbid')
-    
     risky_sections: List[str] = Field(description="List of identified risky sections from the document")
     risk_level: str = Field(description="Overall risk level: Low, Medium, High, Critical")
     risk_summary: str = Field(description="Brief summary of identified risks")
 
-class RiskPhraseResult(BaseModel):
-    """Output schema for risk phrase extractor agent"""
-    model_config = ConfigDict(extra='forbid')
-    
-    phrases: List[Dict[str, str]] = Field(description="Array of risky phrases with their locations and risk types")
+class PhraseItem(BaseSchema):
+    """Individual phrase item with location and risk type"""
+    phrase: str = Field(description="The exact risky phrase from the document")
+    location: str = Field(description="Section or location where the phrase appears")
+    risk_type: str = Field(description="Type of risk this phrase represents")
 
-class SummaryResult(BaseModel):
+class RiskPhraseResult(BaseSchema):
+    """Output schema for risk phrase extractor agent"""
+    phrases: List[PhraseItem] = Field(description="Array of risky phrases with their locations and risk types")
+
+class SummaryResult(BaseSchema):
     """Output schema for summarizer agent"""
-    model_config = ConfigDict(extra='forbid')
-    
     key_points: List[str] = Field(description="List of key summary points")
     document_type: str = Field(description="Type of legal document (terms of service, privacy policy, etc.)")
     complexity_level: str = Field(description="Document complexity level: Simple, Moderate, Complex")

--- a/adk/untangle_agent/sub_agents/demistifier_agent/agent.py
+++ b/adk/untangle_agent/sub_agents/demistifier_agent/agent.py
@@ -48,10 +48,9 @@ risk_phrase_extractor_agent = LlmAgent(
      - Restrictive dispute resolution clauses
      
      For each risky phrase, provide:
-     - The exact text from the document
-     - The section or location where it appears
-     - The type of risk it represents
-     - Why it's concerning for users
+     - phrase: The exact text from the document
+     - location: The section or location where it appears
+     - risk_type: The type of risk it represents (e.g., "Liability", "Data Collection", "Term Changes", etc.)
      
      Focus on phrases that would be highlighted on a frontend interface to warn users.
      """,


### PR DESCRIPTION
This pull request refactors the schema definitions for the demistifier agent to improve consistency, extensibility, and JSON schema generation. The main changes include introducing a new `BaseSchema` class to remove `additionalProperties` from generated schemas, updating all schema classes to inherit from this base, and replacing dictionary-based phrase items with a dedicated `PhraseItem` model for better structure.

### Schema refactoring and extensibility

* Added a `BaseSchema` class that overrides Pydantic's schema generation to recursively remove `additionalProperties` from the output, ensuring cleaner and more predictable JSON schemas. All schema classes now inherit from `BaseSchema` instead of directly from `BaseModel`.
* Removed explicit `model_config = ConfigDict(extra='forbid')` from all schema classes, relying on the new base class for configuration.

### Improved structure for risky phrases

* Introduced a new `PhraseItem` class to represent risky phrases with explicit fields (`phrase`, `location`, and `risk_type`), replacing the previous use of a list of dictionaries. Updated the `RiskPhraseResult` schema to use a list of `PhraseItem` objects.
* Updated the agent prompt documentation to reflect the new structured format for risky phrases, specifying field names and risk types for clarity and frontend compatibility.