### PR TITLE
Fix syntax error in cd_be.yml

### DIFF
--- a/.github/workflows/cd_be.yml
+++ b/.github/workflows/cd_be.yml
@@ -101,7 +101,7 @@ jobs:
             "r2_buckets": [
               {
                 "binding": "${{ vars.BINDING}}",
-                "bucket_name": "${{ vars.BUCKET_NAME }}"",
+                "bucket_name": "${{ vars.BUCKET_NAME }}",
               }
             ]
           }


### PR DESCRIPTION
This pull request makes a minor correction to the `cd_be.yml` workflow file to fix a syntax error.

* Fixed an extra quotation mark in the `bucket_name` value for the `r2_buckets` configuration in `.github/workflows/cd_be.yml`.